### PR TITLE
Add tri-layer support for Fn layer activation

### DIFF
--- a/config/corneish_zen.keymap
+++ b/config/corneish_zen.keymap
@@ -29,6 +29,14 @@
         };
     };
 
+    conditional_layers {
+        compatible = "zmk,conditional-layers";
+        tri_layer {
+            if-layers = <1 2>;
+            then-layer = <3>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 


### PR DESCRIPTION
## Summary
- Add conditional layer configuration to activate Layer 3 (Fn) when both MO1 and MO2 are held simultaneously
- Uses ZMK's built-in `conditional_layers` feature for clean tri-layer implementation

## How it works
| Keys Held | Layer Activated |
|-----------|-----------------|
| MO1 only | Layer 1 (NUMBER) |
| MO2 only | Layer 2 (SYMBOL) |
| MO1 + MO2 | Layer 3 (Fn) |

## Test plan
- [ ] Build firmware successfully via GitHub Actions
- [ ] Flash firmware to keyboard
- [ ] Verify MO1 activates NUMBER layer
- [ ] Verify MO2 activates SYMBOL layer
- [ ] Verify MO1 + MO2 activates Fn layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)